### PR TITLE
[feat #27] Navigation 컴포넌트 구현

### DIFF
--- a/src/components/base/Icon/index.jsx
+++ b/src/components/base/Icon/index.jsx
@@ -1,8 +1,15 @@
 import PropTypes from 'prop-types';
 import { Icon } from '@iconify/react';
 
-const IconComponent = ({ name, color, height }) => {
-  return <Icon icon={name} color={color} height={height} />;
+const IconComponent = ({ name, color, height, ...props }) => {
+  return (
+    <Icon
+      icon={name}
+      color={color}
+      height={height}
+      style={{ ...props.style }}
+    />
+  );
 };
 
 IconComponent.defaultProps = {

--- a/src/components/domain/Navigation/index.jsx
+++ b/src/components/domain/Navigation/index.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import { Icon } from '@components/base';
+import color from '@assets/colors/Color';
+
+const Container = styled.nav`
+  display: flex;
+  width: 100%;
+  height: 70px;
+  justify-content: space-between;
+  position: fixed;
+  bottom: 0;
+  z-index: 5;
+  background: #ffffff;
+  box-shadow: 0px 1px 4px rgba(100, 88, 71, 0.25);
+`;
+
+const Span = styled.span`
+  margin-top: 4px;
+`;
+
+const NavLinkStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 20%;
+  color: ${color.grey};
+  text-decoration: none;
+  font-size: 12px;
+
+  &.active {
+    color: ${color.brown};
+  }
+`;
+
+const Navigation = () => {
+  return (
+    <Container>
+      <NavLink to="" css={NavLinkStyle}>
+        <Icon name="bx:bx-home-heart" height={40} />
+        <Span>홈</Span>
+      </NavLink>
+      <NavLink to="" css={NavLinkStyle}>
+        <Icon name="akar-icons:book" height={40} />
+        <Span>스토리북</Span>
+      </NavLink>
+      <NavLink to="" css={NavLinkStyle}>
+        <Icon name="bi:pencil" height={40} />
+        <Span>일기 쓰기</Span>
+      </NavLink>
+      <NavLink to="" css={NavLinkStyle}>
+        <Icon name="ic:outline-timeline" height={40} />
+        <Span>특별한 순간</Span>
+      </NavLink>
+      <NavLink to="" css={NavLinkStyle}>
+        <Icon name="fluent:people-20-regular" height={40} />
+        <Span>멤버 리스트</Span>
+      </NavLink>
+    </Container>
+  );
+};
+
+export default Navigation;

--- a/src/components/domain/index.jsx
+++ b/src/components/domain/index.jsx
@@ -1,0 +1,1 @@
+export { default as Navigation } from './Navigation';

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import { Navigation } from '@components/domain';
 
 const MainPage = () => {
-  return <div>메인화면입니다.</div>;
+  return (
+    <>
+      <div>메인화면입니다.</div>
+      <Navigation />
+    </>
+  );
 };
 
 export default MainPage;


### PR DESCRIPTION
## 📌 이슈
> closed #27 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- Navigation이 페이지의 뷰포트에서 항상 하단에 고정되도록 구현하였습니다.
- NavLink를 활용하여 현재 사용자가 어느 위치에 해당하는지 active 하게 UI를 제공하도록 구현하였습니다.  

## 📝 요약
<!-- PR 내용 요약 -->
- 여러 페이지에서 사용되는 Domain 단위의 Navigation 컴포넌트 구현

## 📸 첨부
<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->

- 현재는 각 링크에 대한 자세한 URL이 정해지지 않아 모두 동일한 색상으로 보입니다. 
- Navigation의 각 링크에 해당하는 페이지를 구현하실 때 반드시 NavLink에 페이지 url 경로를 작성해주셔야 합니다 !

![image](https://user-images.githubusercontent.com/57757719/145096226-85f9aab2-9d24-4f29-b041-f0ca37487845.png)
