### PR TITLE
[feat #54] Navigation assets 포맷 적용

### DIFF
--- a/src/assets/colors/index.jsx
+++ b/src/assets/colors/index.jsx
@@ -7,7 +7,7 @@ const color = {
   grey: '#C4C4C4',
   grey_50: '#E4E4E4',
   brown: '#645847',
+  brown_25: '#64584740',
   white: '#ffffff', // textColor
 };
-
 export default color;

--- a/src/components/domain/Navigation/index.jsx
+++ b/src/components/domain/Navigation/index.jsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { Icon } from '@components/base';
 import color from '@assets/colors';
+import font from '@assets/fonts';
 
 const Container = styled.nav`
   display: flex;
@@ -29,7 +30,7 @@ const NavLinkStyle = css`
   width: 20%;
   color: ${color.grey};
   text-decoration: none;
-  font-size: 12px;
+  ${font.content_12};
 
   &.active {
     color: ${color.brown};

--- a/src/components/domain/Navigation/index.jsx
+++ b/src/components/domain/Navigation/index.jsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { Icon } from '@components/base';
-import color from '@assets/colors/Color';
+import color from '@assets/colors';
 
 const Container = styled.nav`
   display: flex;
@@ -13,8 +13,8 @@ const Container = styled.nav`
   position: fixed;
   bottom: 0;
   z-index: 5;
-  background: #ffffff;
-  box-shadow: 0px 1px 4px rgba(100, 88, 71, 0.25);
+  background: ${color.white};
+  box-shadow: 0px 1px 4px ${color.brown_25};
 `;
 
 const Span = styled.span`

--- a/src/components/domain/Navigation/index.jsx
+++ b/src/components/domain/Navigation/index.jsx
@@ -40,23 +40,23 @@ const Navigation = () => {
   return (
     <Container>
       <NavLink to="" css={NavLinkStyle}>
-        <Icon name="bx:bx-home-heart" height={40} />
+        <Icon name="bx:bx-home-heart" height={24} />
         <Span>홈</Span>
       </NavLink>
       <NavLink to="" css={NavLinkStyle}>
-        <Icon name="akar-icons:book" height={40} />
+        <Icon name="akar-icons:book" height={24} />
         <Span>스토리북</Span>
       </NavLink>
       <NavLink to="" css={NavLinkStyle}>
-        <Icon name="bi:pencil" height={40} />
+        <Icon name="bi:pencil" height={24} />
         <Span>일기 쓰기</Span>
       </NavLink>
       <NavLink to="" css={NavLinkStyle}>
-        <Icon name="ic:outline-timeline" height={40} />
+        <Icon name="ic:outline-timeline" height={24} />
         <Span>특별한 순간</Span>
       </NavLink>
       <NavLink to="" css={NavLinkStyle}>
-        <Icon name="fluent:people-20-regular" height={40} />
+        <Icon name="fluent:people-20-regular" height={24} />
         <Span>멤버 리스트</Span>
       </NavLink>
     </Container>


### PR DESCRIPTION
## 📌 이슈
> closed #54 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- assets의 color 값을 통한 Icon 스타일 지정
- assets의 font 값을 통한 Icon 스타일 지정

## 📝 요약

<!-- PR 내용 요약 -->
- color와 font 값을 assets에서 불러와 공통 변수를 사용하여 스타일을 지정하였습니다.

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
- 현재는 각 링크에 대한 자세한 URL이 정해지지 않아 모두 동일한 색상으로 보입니다.
- Navigation의 각 링크에 해당하는 페이지를 구현하실 때 반드시 NavLink에 페이지 url 경로를 작성해주셔야 합니다 !

![image](https://user-images.githubusercontent.com/57757719/145167653-49042722-8495-432f-a69d-e30a0bfdf016.png)
