### PR TITLE
[feat #49]

### DIFF
--- a/src/components/base/Modal/index.jsx
+++ b/src/components/base/Modal/index.jsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import color from '@assets/colors';
+import font from '@assets/fonts';
 import useClickAway from '@hooks/useClickAway';
 import { Button } from '@components/base';
 
@@ -27,21 +28,15 @@ const ModalContainer = styled.div`
   box-sizing: border-box;
   padding: 40px 32px;
   text-align: center;
+  ${font.content_16};
 `;
 
 const ButtonWrapper = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 38px;
-  gap: 16px;
+  gap: 32px;
 `;
-
-// const Button = styled.button`
-//   border: none;
-//   background-color: transparent;
-//   padding: 0;
-//   cursor: pointer;
-// `;
 
 const Modal = ({ children, width, visible, onClose, ...props }) => {
   const ref = useClickAway(() => {

--- a/src/components/base/Modal/index.jsx
+++ b/src/components/base/Modal/index.jsx
@@ -42,7 +42,7 @@ const Button = styled.button`
   cursor: pointer;
 `;
 
-const Modal = ({ children, width, height, visible, onClose, ...props }) => {
+const Modal = ({ children, width, visible, onClose, ...props }) => {
   const ref = useClickAway(() => {
     onClose();
   });
@@ -50,9 +50,9 @@ const Modal = ({ children, width, height, visible, onClose, ...props }) => {
   const containerStyle = useMemo(() => {
     return {
       width,
-      height,
     };
-  }, [width, height]);
+  }, [width]);
+
   const el = useMemo(() => document.createElement('div'), []);
 
   useEffect(() => {
@@ -61,6 +61,21 @@ const Modal = ({ children, width, height, visible, onClose, ...props }) => {
       document.body.removeChild(el);
     };
   }, [el]);
+
+  useEffect(() => {
+    if (visible) {
+      document.body.style.cssText = `
+      position: fixed;
+      top: -${window.scrollY}px;
+      overflow-y: scroll;
+      width: 100%;`;
+      return () => {
+        const scrollY = document.body.style.top;
+        document.body.style.cssText = '';
+        window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+      };
+    }
+  }, [visible]);
 
   return ReactDOM.createPortal(
     <BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
@@ -83,7 +98,6 @@ const Modal = ({ children, width, height, visible, onClose, ...props }) => {
 Modal.propTypes = {
   children: PropTypes.node.isRequired,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   visible: PropTypes.bool,
   onClose: PropTypes.func,
   style: PropTypes.object,
@@ -93,6 +107,7 @@ Modal.defaultProps = {
   width: '60%',
   visible: false,
   onClose: () => {},
+  style: {},
 };
 
 export default Modal;

--- a/src/components/base/Modal/index.jsx
+++ b/src/components/base/Modal/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import color from '@assets/colors';
 import useClickAway from '@hooks/useClickAway';
+import { Button } from '@components/base';
 
 const BackgroundDim = styled.div`
   position: fixed;
@@ -35,12 +36,12 @@ const ButtonWrapper = styled.div`
   gap: 16px;
 `;
 
-const Button = styled.button`
-  border: none;
-  background-color: transparent;
-  padding: 0;
-  cursor: pointer;
-`;
+// const Button = styled.button`
+//   border: none;
+//   background-color: transparent;
+//   padding: 0;
+//   cursor: pointer;
+// `;
 
 const Modal = ({ children, width, visible, onClose, ...props }) => {
   const ref = useClickAway(() => {

--- a/src/stories/components/Modal.stories.jsx
+++ b/src/stories/components/Modal.stories.jsx
@@ -9,7 +9,7 @@ export default {
 export const Default = () => {
   const [visible, setVisible] = useState(false);
   return (
-    <div>
+    <div style={{ height: 10000 }}>
       <button
         type="button"
         onClick={() => {
@@ -20,6 +20,33 @@ export const Default = () => {
       </button>
       <Modal visible={visible} onClose={() => setVisible(false)}>
         총 1명의 인원을 초대하시겠습니까?
+      </Modal>
+    </div>
+  );
+};
+
+export const LongText = () => {
+  const [visible, setVisible] = useState(false);
+  return (
+    <div style={{ height: 10000 }}>
+      <button
+        type="button"
+        onClick={() => {
+          setVisible(true);
+        }}
+      >
+        show Modal
+      </button>
+      <Modal visible={visible} onClose={() => setVisible(false)}>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry. Lorem Ipsum has been the industry's standard dummy text ever
+        since the 1500s, when an unknown printer took a galley of type and
+        scrambled it to make a type specimen book. It has survived not only five
+        centuries, but also the leap into electronic typesetting, remaining
+        essentially unchanged. It was popularised in the 1960s with the release
+        of Letraset sheets containing Lorem Ipsum passages, and more recently
+        with desktop publishing software like Aldus PageMaker including versions
+        of Lorem Ipsum.
       </Modal>
     </div>
   );


### PR DESCRIPTION
## 📌 이슈
> closed #49 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- 모달 뒤의 스크롤 방지
- Button 컴포넌트 사용

## 📝 요약
<!-- PR 내용 요약 -->
- 모달이 열렸을 때, 뒤의 스크롤을 방지하는 기능을 추가했습니다.
- Button 컴포넌트를 사용했는데 모바일에서는 (아이폰 기준) 버튼에 색이 자동으로 입혀집니다. (PC 환경에서는 검은색 그대로 나옴)
  이 부분에 수정이 필요할지 / 수정을 한다면 Button 컴포넌트에서 이루어져야 할지, Modal 컴포넌트에서 이루어져야 할지 생각해봐야 할 것 같습니다.

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
https://deploy-preview-61--jungdam-storybook.netlify.app
<!-- ex) 링크, 스크린샷 -->
![IMG_042438B14E02-1](https://user-images.githubusercontent.com/71081893/145236293-e4a20f8d-ab2c-45fe-a92b-91c2d8f76847.jpeg)

