### PR TITLE
[feat #51]

### DIFF
--- a/src/components/base/Input/index.jsx
+++ b/src/components/base/Input/index.jsx
@@ -1,22 +1,24 @@
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import color from '@assets/colors';
+import font from '@assets/fonts';
 
 const inputSizes = {
-  sm: '24px',
-  base: '32px',
+  sm: `${font.content_12}`,
+  base: `${font.content_16}`,
+  lg: `${font.content_18}`,
 };
 
 const StyledInput = styled.input`
   display: block;
-  height: ${({ size }) => inputSizes[size]};
+  width: ${({ width }) => width};
   box-sizing: border-box;
   border: none;
   border-bottom: 1px solid ${color.brown};
-  font-size: 16px;
   background-color: transparent;
   color: ${color.black};
   outline: none;
+  ${({ size }) => inputSizes[size]};
 
   &::placeholder {
     color: ${color.grey};
@@ -38,20 +40,7 @@ const StyledInput = styled.input`
   }
 `;
 
-const Input = ({
-  width,
-  isFullWidth,
-  size,
-  onChange,
-  name,
-  error,
-  success,
-  ...props
-}) => {
-  const inputStyle = {
-    width: isFullWidth ? `100%` : `${width}px`,
-  };
-
+const Input = ({ width, onChange, size, name, error, success, ...props }) => {
   let status = '';
 
   if (error) {
@@ -66,27 +55,27 @@ const Input = ({
       onChange={onChange}
       name={name}
       size={size}
+      width={width}
       className={status || undefined}
       {...props}
-      style={{ ...props.style, ...inputStyle }}
+      style={{ ...props.style }}
     />
   );
 };
 
 Input.propTypes = {
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  width: PropTypes.string,
   isFullWidth: PropTypes.bool,
   onChange: PropTypes.func,
   name: PropTypes.string.isRequired,
-  size: PropTypes.oneOf(['base', 'sm']),
+  size: PropTypes.oneOf(['sm', 'base', 'lg']),
   error: PropTypes.bool,
   success: PropTypes.bool,
   style: PropTypes.object,
 };
 
 Input.defaultProps = {
-  width: 288,
-  isFullWidth: false,
+  width: '100%',
   onChange: () => {},
   size: 'base',
   error: false,

--- a/src/stories/components/Input.stories.jsx
+++ b/src/stories/components/Input.stories.jsx
@@ -14,12 +14,6 @@ export const Date = (args) => {
   return <Input {...args} type="date" placeholder="날짜를 입력해주세요." />;
 };
 
-export const Small = (args) => {
-  return (
-    <Input {...args} type="text" size="sm" placeholder="내용을 입력해주세요." />
-  );
-};
-
 export const Error = (args) => {
   return <Input {...args} error type="text" placeholder="Error" />;
 };


### PR DESCRIPTION
## 📌 이슈
> closed #51 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- input width 기본값 (100%) 지정
- input 컴포넌트의 크기를 font-size 로 조절

## 📝 요약

<!-- PR 내용 요약 -->
- font-size 를 통해 input 컴포넌트의 크기를 조절합니다.
  prop ... size = [sm, base, lg]
- date 형식에서의 디자인 변경은 고도화때 하면 좋을 것 같아 일단 미뤄뒀습니다.
- input 에서 영어와 한글의 weight 차이가 존재하여 어떻게 처리할지 고민중입니다.
- PC와 모바일(아이폰 크롬) 에서의 디자인이 다릅니다. 모바일에서는 라운딩된 상태가 조금 남아있습니다. (outline과 boder가 none인 상태에서 border-bottom만 지정하여 구현)

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
 https://deploy-preview-64--jungdam-storybook.netlify.app
<!-- ex) 링크, 스크린샷 -->
- 영어, 한글 글씨크기 weight 차이
![image](https://user-images.githubusercontent.com/71081893/145252867-2f2457c6-1460-489c-aca5-e4470fa45905.png)

- 모바일 크롬에서는 해당 현상이 없습니다!
  하지만 디자인이 살짝 문제가 있는 것 같습니다.
![image](https://user-images.githubusercontent.com/71081893/145254185-c177de8a-b299-483b-845f-97427de66e8c.jpeg)