### PR TITLE
[feat #86]

### DIFF
--- a/src/components/base/Avatar/index.jsx
+++ b/src/components/base/Avatar/index.jsx
@@ -6,6 +6,7 @@ import defaultUser from '@assets/Image/defaultUser.png';
 
 const Sizes = {
   large: '80px',
+  medium: '50px',
   base: '32px',
 };
 
@@ -26,20 +27,22 @@ const AvatarWrapper = styled.div`
 `;
 
 const Avatar = ({ size, src, ...props }) => {
+  const avatarSrc = src === '' ? defaultUser : src;
+
   return (
     <AvatarWrapper {...props} size={size}>
-      <Image src={src} alt="userProfile" mode="cover" />
+      <Image src={avatarSrc} alt="userProfile" mode="cover" />
     </AvatarWrapper>
   );
 };
 
 Avatar.defaultProps = {
   size: 'base',
-  src: defaultUser,
+  src: '',
 };
 
 Avatar.propTypes = {
-  size: PropTypes.oneOf(['base', 'large']),
+  size: PropTypes.oneOf(['base', 'medium', 'large']),
   src: PropTypes.string,
 };
 

--- a/src/components/domain/Header/index.jsx
+++ b/src/components/domain/Header/index.jsx
@@ -5,6 +5,7 @@ import color from '@assets/colors';
 import font from '@assets/fonts';
 import Logo from '@assets/Image/Logo.svg';
 import { useNavigate } from 'react-router';
+import PropTypes from 'prop-types';
 
 const HeaderContainer = styled.header`
   display: flex;
@@ -99,14 +100,32 @@ export const MainHeader = ({ groupTitle, familyMotto, role }) => {
   );
 };
 
-export const ServiceInfoHeader = () => {
+MainHeader.propTypes = {
+  groupTitle: PropTypes.string.isRequired,
+  familyMotto: PropTypes.string.isRequired,
+  role: PropTypes.oneOf(['OWNER', 'MEMBER']),
+};
+
+MainHeader.defaultProps = {
+  role: 'MEMBER',
+};
+
+export const ServiceInfoHeader = ({ src }) => {
   return (
     <Header
       style={{ boxShadow: `0px 1px 4px rgba(100, 88, 71, 0.25)` }}
       leftComponent={<Image src={Logo} alt="logo" block width="38px" />}
-      rightComponent={<Avatar />}
+      rightComponent={<Avatar src={src} />}
     />
   );
+};
+
+ServiceInfoHeader.propTypes = {
+  src: PropTypes.string,
+};
+
+ServiceInfoHeader.defaultProps = {
+  src: '',
 };
 
 export const DetailPageHeader = ({ pageTitle }) => {
@@ -127,6 +146,10 @@ export const DetailPageHeader = ({ pageTitle }) => {
   );
 };
 
+DetailPageHeader.propTypes = {
+  pageTitle: PropTypes.string.isRequired,
+};
+
 export const OnlyInfoHeader = ({ pageTitle }) => {
   return (
     <Header
@@ -134,4 +157,8 @@ export const OnlyInfoHeader = ({ pageTitle }) => {
       leftComponent={<HeadingContent>{pageTitle}</HeadingContent>}
     />
   );
+};
+
+OnlyInfoHeader.propTypes = {
+  pageTitle: PropTypes.string.isRequired,
 };

--- a/src/components/domain/Header/index.jsx
+++ b/src/components/domain/Header/index.jsx
@@ -18,6 +18,7 @@ const HeaderContainer = styled.header`
   align-items: center;
   margin: 0;
   padding: 0 32px 0 32px;
+  background-color: ${color.white};
 `;
 
 const HeaderContent = styled.div`


### PR DESCRIPTION
## 📌 이슈
> closed #86 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- Header 에서 누락된 Avatar Prop 추가
  - `ServiceInfoHeader = ({ src })` ... src 에 Avatar 에 쓰일 이미지 src 가 들어갑니다.
- Header propTypes 추가
- Header 에서 사용되는 Avatar 컴포넌트의 src 기본값 수정
- Avatar 컴포넌트의 사이즈 추가

## 📝 요약

<!-- PR 내용 요약 -->
- Header 에서의 Prop 를 수정, defaultProp 를 추가했습니다.
- Avatar 컴포넌트의 src 기본값 수정 / 사이즈 추가가 이루어졌습니다. 
## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
https://deploy-preview-87--jungdam-storybook.netlify.app

<!-- ex) 링크, 스크린샷 -->
- Avatar 컴포넌트에서 Size `medium: '50px'` 추가
![image](https://user-images.githubusercontent.com/71081893/145666835-2d15e102-9bc5-431b-8792-69374b1ecb5b.png)
