### PR TITLE
[feat #99] 모바일 웹 가상 키보드에 따른 기존 CSS 밀림 현상

### DIFF
--- a/src/components/base/Button/index.jsx
+++ b/src/components/base/Button/index.jsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import font from '@assets/fonts';
 import color from '@assets/colors';
+import { forwardRef } from 'react';
 
 const Root = styled.button`
   display: flex;
@@ -35,10 +36,19 @@ const Root = styled.button`
 // mode : 기본 꽉찬 버튼 (Primary), 선 있는 버튼 (Border)
 // bgColor : 배경 컬러
 // gap : 버튼 안의 요소 사이의 간격
-const Button = ({ children, mode, bgColor, gap = '2px', ...props }) => (
-  <Root type="button" bgColor={bgColor} className={mode} gap={gap} {...props}>
-    {children}
-  </Root>
+const Button = forwardRef(
+  ({ children, mode, bgColor, gap = '2px', ...props }, ref) => (
+    <Root
+      type="button"
+      bgColor={bgColor}
+      className={mode}
+      gap={gap}
+      ref={ref}
+      {...props}
+    >
+      {children}
+    </Root>
+  ),
 );
 
 export default Button;

--- a/src/components/base/Input/index.jsx
+++ b/src/components/base/Input/index.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import color from '@assets/colors';
 import font from '@assets/fonts';
+import { forwardRef } from 'react';
 
 const inputSizes = {
   sm: `${font.content_12}`,
@@ -40,28 +41,31 @@ const StyledInput = styled.input`
   }
 `;
 
-const Input = ({ width, onChange, size, name, error, success, ...props }) => {
-  let status = '';
+const Input = forwardRef(
+  ({ width, onChange, size, name, error, success, ...props }, ref) => {
+    let status = '';
 
-  if (error) {
-    status = 'error';
-  }
-  if (success) {
-    status = 'success';
-  }
+    if (error) {
+      status = 'error';
+    }
+    if (success) {
+      status = 'success';
+    }
 
-  return (
-    <StyledInput
-      onChange={onChange}
-      name={name}
-      size={size}
-      width={width}
-      className={status || undefined}
-      {...props}
-      style={{ ...props.style }}
-    />
-  );
-};
+    return (
+      <StyledInput
+        onChange={onChange}
+        name={name}
+        size={size}
+        width={width}
+        className={status || undefined}
+        {...props}
+        style={{ ...props.style }}
+        ref={ref}
+      />
+    );
+  },
+);
 
 Input.propTypes = {
   width: PropTypes.string,

--- a/src/components/base/ProgressBar/index.jsx
+++ b/src/components/base/ProgressBar/index.jsx
@@ -15,6 +15,7 @@ const Container = styled.div`
 
 const HighLight = styled.div`
   width: ${({ width }) => width};
+  height: 5px;
   border-radius: 4px;
   background: ${({ active }) => (active ? color.brown : color.grey)};
 `;
@@ -29,6 +30,7 @@ const renderHighLight = (totalStep, currentStep) => {
         key={i}
         width={calculateWidth}
         active={i < currentStep && true}
+        className="bar"
       />,
     );
   }

--- a/src/components/domain/DiaryCreateStepTwo/index.jsx
+++ b/src/components/domain/DiaryCreateStepTwo/index.jsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import font from '@assets/fonts';
 import { Input, Textarea } from '@components/base';
+import { forwardRef } from 'react';
 
 const Container = styled.div`
   display: flex;
@@ -18,7 +19,7 @@ const InputStyle = css`
   ${font.content_16}
 `;
 
-const DiaryCreateStepTwo = () => {
+const DiaryCreateStepTwo = forwardRef((_, ref) => {
   const onChange = (e) => {
     console.log(e.target.value);
   };
@@ -32,12 +33,14 @@ const DiaryCreateStepTwo = () => {
         onChange={onChange}
         placeholder="제목을 입력해주세요."
         css={InputStyle}
+        ref={ref}
+        autoComplete="off"
       />
 
       <Title>일기장을 적어볼까요 ?</Title>
       <Textarea />
     </Container>
   );
-};
+});
 
 export default DiaryCreateStepTwo;

--- a/src/components/domain/DiaryCreateStepTwo/index.jsx
+++ b/src/components/domain/DiaryCreateStepTwo/index.jsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import font from '@assets/fonts';
 import { Input, Textarea } from '@components/base';
-import { forwardRef } from 'react';
 
 const Container = styled.div`
   display: flex;
@@ -19,7 +18,7 @@ const InputStyle = css`
   ${font.content_16}
 `;
 
-const DiaryCreateStepTwo = forwardRef((_, ref) => {
+const DiaryCreateStepTwo = () => {
   const onChange = (e) => {
     console.log(e.target.value);
   };
@@ -33,7 +32,6 @@ const DiaryCreateStepTwo = forwardRef((_, ref) => {
         onChange={onChange}
         placeholder="제목을 입력해주세요."
         css={InputStyle}
-        ref={ref}
         autoComplete="off"
       />
 
@@ -41,6 +39,6 @@ const DiaryCreateStepTwo = forwardRef((_, ref) => {
       <Textarea />
     </Container>
   );
-});
+};
 
 export default DiaryCreateStepTwo;

--- a/src/pages/DiaryCreatePage/index.jsx
+++ b/src/pages/DiaryCreatePage/index.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import React, { useState } from 'react';
+import React, { useState, useRef, useLayoutEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Header,
@@ -27,6 +27,24 @@ const ButtonStyle = {
 const DiaryCreatePage = () => {
   const [step, setStep] = useState(1);
   const navigate = useNavigate();
+
+  const titleRef = useRef();
+  const buttonRef = useRef();
+
+  useLayoutEffect(() => {
+    const detectMobileKeyboard = () => {
+      if (document.activeElement.tagName === 'INPUT') {
+        titleRef.current.focus();
+        titleRef.current.scrollIntoView({ block: 'end' });
+        buttonRef.current.style.display =
+          buttonRef.current.style.display === 'none' ? 'block' : 'none';
+      }
+    };
+
+    window.addEventListener('resize', detectMobileKeyboard);
+
+    return () => window.removeEventListener('resize', detectMobileKeyboard);
+  }, [step]);
 
   const handleNextButtonClick = () => {
     setStep(() => step + 1);
@@ -72,7 +90,7 @@ const DiaryCreatePage = () => {
     if (step === 1) {
       return <DiaryCreateStepOne />;
     } else if (step === 2) {
-      return <DiaryCreateStepTwo />;
+      return <DiaryCreateStepTwo ref={titleRef} />;
     } else if (step === 3) {
       return <DiaryCreateStepThree />;
     }
@@ -85,13 +103,19 @@ const DiaryCreatePage = () => {
         centerComponent={centerHeaderContent()}
       />
 
-      <ProgressBar css={DefaultMarginTop} totalStep={3} currentStep={step} />
+      <ProgressBar
+        className="progress"
+        css={DefaultMarginTop}
+        totalStep={3}
+        currentStep={step}
+      />
 
       {renderDiaryCreateForm()}
 
       <Button
         mode="primary"
         style={{ ...ButtonStyle }}
+        ref={buttonRef}
         onClick={step === 3 ? handleSubmitButtonClick : handleNextButtonClick}
       >
         {step === 3 ? '확인' : '다음'}

--- a/src/pages/DiaryCreatePage/index.jsx
+++ b/src/pages/DiaryCreatePage/index.jsx
@@ -28,23 +28,23 @@ const DiaryCreatePage = () => {
   const [step, setStep] = useState(1);
   const navigate = useNavigate();
 
-  const titleRef = useRef();
   const buttonRef = useRef();
 
   useLayoutEffect(() => {
     const detectMobileKeyboard = () => {
-      if (document.activeElement.tagName === 'INPUT') {
-        titleRef.current.focus();
-        titleRef.current.scrollIntoView({ block: 'end' });
-        buttonRef.current.style.display =
-          buttonRef.current.style.display === 'none' ? 'block' : 'none';
-      }
+      const activeElement = document.activeElement;
+
+      activeElement.focus();
+      activeElement.scrollIntoView({ block: 'end' });
+
+      buttonRef.current.style.display =
+        buttonRef.current.style.display === 'none' ? 'block' : 'none';
     };
 
     window.addEventListener('resize', detectMobileKeyboard);
 
     return () => window.removeEventListener('resize', detectMobileKeyboard);
-  }, [step]);
+  }, []);
 
   const handleNextButtonClick = () => {
     setStep(() => step + 1);
@@ -90,7 +90,7 @@ const DiaryCreatePage = () => {
     if (step === 1) {
       return <DiaryCreateStepOne />;
     } else if (step === 2) {
-      return <DiaryCreateStepTwo ref={titleRef} />;
+      return <DiaryCreateStepTwo />;
     } else if (step === 3) {
       return <DiaryCreateStepThree />;
     }


### PR DESCRIPTION
## 📌 이슈
> closed #99 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- Base 컴포넌트에 forwardRef 기능 확장
- 모바일 웹의 가상 키보드 활성화에 따른 UI 개선을 위해 useLayoutEffect 활용하여 기능 구현

## 📝 요약
- 모바일 웹의 가상 키보드 활성화에 따라 깨지는 CSS 요소들의 경우 예외적인 CSS 구현이 필요합니다.
- 저의 경우 버튼의 CSS가 깨지게 되어 키보드가 활성화 되었을 때와 아닐 때를 resize 이벤트를 통해 키보드가 활성화 되었을 때의 경우는 display를 none으로 비활성화 시 다시 버튼이 뷰에 나타나게 되는 로직으로 1차 이슈 해결했습니다. 
- 이 부분의 이슈는 중요하다 생각되며 각자의 가상 키보드가 활성화 되어지는 페이지에서 개별적인 구현이 필요해 보입니다.

## 📸 첨부
- 노션에 정리한 이슈 문서
https://www.notion.so/backend-devcourse/CSS-153c1f320e2a44c7986026ec3b4bc566

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
- 이슈 발견 상황
![image](https://user-images.githubusercontent.com/57757719/145945940-42bc8e48-0484-498a-8317-dcfa698a0aa8.png)

- 이슈 1차 해결 상황
![image](https://user-images.githubusercontent.com/57757719/145946023-bdf5f1d5-7ab0-49f5-8379-ab5cf959be58.png)
