### PR TITLE
[feat #132]

### DIFF
--- a/src/common/api/MemberList.jsx
+++ b/src/common/api/MemberList.jsx
@@ -1,0 +1,13 @@
+import api from './api';
+
+export const searchUser = async (email) =>
+  await api({
+    url: `/api/v1/members/search?email=${email}`,
+    method: 'GET',
+  });
+
+export const inviteUser = async (albumId) =>
+  await api({
+    url: `/api/v1/albums/${albumId}/invitations`,
+    method: 'POST',
+  });

--- a/src/common/api/memberList.jsx
+++ b/src/common/api/memberList.jsx
@@ -6,8 +6,8 @@ export const searchUser = async (email) =>
     method: 'GET',
   });
 
-export const inviteUser = async (albumId) =>
-  await api({
-    url: `/api/v1/albums/${albumId}/invitations`,
-    method: 'POST',
-  });
+// export const inviteUser = async (albumId) =>
+//   await api({
+//     url: `/api/v1/albums/${albumId}/invitations`,
+//     method: 'POST',
+//   });

--- a/src/pages/MemberInvitePage/index.jsx
+++ b/src/pages/MemberInvitePage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import DefaultContainer from '@styles/DefaultContainer';
 import color from '@assets/colors';
@@ -6,24 +6,7 @@ import font from '@assets/fonts';
 import { Input, Button, Icon, Spinner, Avatar, Modal } from '@components/base';
 import { DetailPageHeader } from '@components/domain';
 import { useForm } from '@hooks';
-
-const DUMMY_DATA = [
-  {
-    username: '테스트1',
-    email: 'test1@gmail.com',
-    avatar: 'https://picsum.photos/300/600',
-  },
-  {
-    username: '테스트2',
-    email: 'test2@gmail.com',
-    avatar: 'https://picsum.photos/300/600',
-  },
-  {
-    username: '테스트3',
-    email: 'test3@gmail.com',
-    avatar: 'https://picsum.photos/300/600',
-  },
-];
+import { searchUser } from '@api/searchUser';
 
 const MemberInvitePageWrapper = styled(DefaultContainer)`
   width: 100%;
@@ -45,7 +28,6 @@ const UserWrapper = styled.div`
   border-radius: 15px;
   padding: 8px;
   gap: 16px;
-  background-color: ${({ isToggle }) => (isToggle ? color.brown : color.white)};
 `;
 
 const TextWrapper = styled.div`
@@ -53,9 +35,6 @@ const TextWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   gap: 8px;
-  > span {
-    color: ${({ isToggle }) => (isToggle ? color.white : color.black)};
-  }
 `;
 
 const ButtonWrapper = styled.div`
@@ -67,38 +46,72 @@ const ButtonWrapper = styled.div`
   box-sizing: border-box;
 `;
 
+const SerchedListWrapper = styled.div`
+  z-index: 999;
+  position: absolute;
+  top: 92px;
+  display: flex;
+  justify-content: space-between;
+  border: 1px solid ${color.grey_50};
+  width: 100%;
+  padding: 14px;
+  background-color: ${color.white};
+  box-shadow: 0px 12px 40px -12px;
+  cursor: pointer;
+`;
+
+const LoadingtWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
 const MemberInvitePage = () => {
-  const [searchInfo, setSearchInfo] = useState([]);
+  const inputref = useRef();
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [ModalVisible, setModalVisible] = useState(false);
-  const [isToggle, setIsToggle] = useState(false);
+  const [searchInfo, setSearchInfo] = useState([]);
   const { values, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: {
       email: '',
     },
     onSubmit: async () => {
-      const ans = DUMMY_DATA.filter((data) => {
-        return data.email.includes(values.email);
-      });
-      setSearchInfo(ans);
+      try {
+        const {
+          data: { data },
+        } = await searchUser(values.email);
+        setSearchInfo((values) => values.concat(data));
+      } catch (e) {
+        alert('해당하는 이메일의 사용자를 찾을 수 없습니다.');
+      }
     },
   });
 
-  const searchUserList = (list) =>
-    list.map(({ username, email, avatar }) => (
-      <UserWrapper onClick={onToggle} isToggle={isToggle}>
+  const onSelectUser = () => {
+    const curUser = searchInfo[0];
+    selectedUsers.findIndex((value) => value.email === curUser.email) === -1 &&
+      setSelectedUsers((selectedUsers) => [...selectedUsers, curUser]);
+    inputref.current.value = '';
+    setSearchInfo([]);
+  };
+
+  const searchedUserList = (list) =>
+    list.map(({ nickname, email }, index) => (
+      <SerchedListWrapper onClick={onSelectUser} key={index}>
+        <span>{nickname}</span>
+        <span>{email}</span>
+      </SerchedListWrapper>
+    ));
+
+  const selectedUserList = (list) =>
+    list.map(({ nickname, email, avatar }, index) => (
+      <UserWrapper key={index}>
         <Avatar size="medium" src={avatar} />
-        <TextWrapper isToggle={isToggle}>
-          <span>{username}</span>
+        <TextWrapper>
+          <span>{nickname}</span>
           <span>{email}</span>
         </TextWrapper>
       </UserWrapper>
     ));
-
-  const onToggle = async (e) => {
-    setIsToggle((state) => !state);
-    setSelectedUsers(searchInfo);
-  };
 
   const OpenModal = () => {
     setModalVisible(true);
@@ -114,17 +127,25 @@ const MemberInvitePage = () => {
     <MemberInvitePageWrapper>
       <DetailPageHeader pageTitle="초대하기" />
       <SearchWrapper onSubmit={handleSubmit}>
-        <Input
-          name="email"
-          onChange={handleChange}
-          placeholder="찾을 멤버의 이메일을 입력해주세요."
-        ></Input>
-        <Button onClick={handleSubmit}>
-          <Icon name="carbon:search" color={color.brown} />
-        </Button>
+        <>
+          <Input
+            name="email"
+            onChange={handleChange}
+            placeholder="찾을 멤버의 이메일을 입력해주세요."
+            ref={inputref}
+          ></Input>
+          <Button onClick={handleSubmit}>
+            <Icon name="carbon:search" color={color.brown} />
+          </Button>
+        </>
+        {searchedUserList(searchInfo)}
       </SearchWrapper>
-      {isLoading && <Spinner isLoading={isLoading} />}
-      {searchUserList(searchInfo)}
+      {selectedUserList(selectedUsers)}
+      {isLoading && (
+        <LoadingtWrapper>
+          <Spinner isLoading={isLoading} size={24} />
+        </LoadingtWrapper>
+      )}
       <ButtonWrapper>
         <Button mode="primary" onClick={OpenModal}>
           초대하기


### PR DESCRIPTION
## 📌 이슈
> closed #132 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- 멤버 초대 페이지 회원 email 검색 API 연동 & 기능 구현

## 📝 요약

<!-- PR 내용 요약 -->
- API 이메일 검색 기능을 구현했습니다.
- 상태관리때문에 너무 애를 먹어서 시간을 엄청 잡아먹었습니다.. 그래도 문제 원인과 해결법읊 찾아서 행복합니다..
- 이메일은 고유값이라 검색 시, 무조건 한 개 이하의 객체가 나오기 때문에 상태에 바로 넣어주면서 관리하는 방법으로 추후에 리펙토링 예정입니다.
  - 상태와 비동기에 대한 자세한 설명 너무 감사드립니다 ㅠㅠ
- 초대하기 버튼의 API 통신은 아직 미구현된 상태입니다.
- 이메일 검색 시, 검색 결과가 반환되지 않을 떄 어떻게 보여줘야할까 고민헀는데, 일단 alert 외에 더 좋은 방법은 생각나지 않은 상태입니다.
- 이메일 검색 결과 영역의 위치 확인 필요


## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
![image](https://user-images.githubusercontent.com/71081893/146436841-e1db7855-e37e-4d94-ab21-04a3f32a316d.jpeg)
---
---
![image](https://user-images.githubusercontent.com/71081893/146436859-b9752f8c-c78b-4bb0-bd66-dd5226127e43.jpeg)
---
---
![image](https://user-images.githubusercontent.com/71081893/146436880-a8db04b6-100c-400d-a1af-4fc13cfc3b76.jpeg)
---
---
- 선택된 유저가 있을 경우 (모달 내 텍스트 줄바꿈 다음 커밋에서 처리)
![image](https://user-images.githubusercontent.com/71081893/146436901-f40b18da-30fd-40fc-8b87-6f89227b295a.jpeg)
---
---
- 선택된 유저가 없을 경우
![image](https://user-images.githubusercontent.com/71081893/146436922-5a34d6b7-7fa4-435d-bf53-8c70664702b8.jpeg)
---
---
- 이메일 검색 결과를 찾지 못한 경우
![image](https://user-images.githubusercontent.com/71081893/146437059-3d410243-dc76-4cf8-8272-4003cf4a7cb8.jpeg)