### PR TITLE
[feat #138] 일기 생성 페이지 사용자 입력 1단계 예외처리 구현

### DIFF
--- a/src/common/api/getExistenceDiaryDate.jsx
+++ b/src/common/api/getExistenceDiaryDate.jsx
@@ -1,0 +1,11 @@
+import api from './api';
+
+export const getExistenceDiaryDate = async ({ albumId, date }) => {
+  const {
+    data: { data },
+  } = await api({
+    url: `/api/v1/albums/${albumId}/diaries/search?q=${date}`,
+  });
+
+  return data;
+};

--- a/src/common/api/postDiaryCreate.jsx
+++ b/src/common/api/postDiaryCreate.jsx
@@ -1,10 +1,12 @@
 import api from './api';
 
-export const postDiaryCreate = async (albumId, body) => {
-  const { data } = await api({
+export const postDiaryCreate = async ({ albumId, submitData }) => {
+  const {
+    data: { data },
+  } = await api({
     url: `/api/v1/albums/${albumId}/diaries`,
     type: 'POST',
-    params: body,
+    params: submitData,
   });
 
   return data;

--- a/src/components/domain/DiaryCreateStepOne/index.jsx
+++ b/src/components/domain/DiaryCreateStepOne/index.jsx
@@ -12,7 +12,13 @@ const Title = styled.span`
   ${font.heading_24};
 `;
 
-const DiaryCreateStepOne = ({ onChange, date }) => {
+const ErrorText = styled.span`
+  margin-top: 5px;
+  font-size: 14px;
+  color: red;
+`;
+
+const DiaryCreateStepOne = ({ onChange, date, dateError }) => {
   const getTodayDate = () => {
     let today = new Date();
     let dd = today.getDate();
@@ -43,6 +49,7 @@ const DiaryCreateStepOne = ({ onChange, date }) => {
         max={getTodayDate()}
         value={date}
       />
+      {dateError && <ErrorText>{dateError}</ErrorText>}
     </Container>
   );
 };

--- a/src/pages/DiaryCreatePage/index.jsx
+++ b/src/pages/DiaryCreatePage/index.jsx
@@ -169,16 +169,18 @@ const DiaryCreatePage = () => {
         recordedAt: date,
       };
 
-      // albumId 조회 코드 구현 필요
-      // 반환된 diaryId에 대한 navigate 코드 구현 필요
-      const { data } = await postDiaryCreate(5, submitData);
-      console.log(data);
+      const data = {
+        albumId,
+        submitData,
+      };
+
+      const { diaryId } = await postDiaryCreate(data);
+      navigate(`../${diaryId}`);
     } catch (e) {
-      console.log('fail');
       console.log(e.message);
+
+      return;
     }
-    // api 코드 추가 예정
-    // navigate('../diary');
   };
 
   const leftHeaderContent = () => {

--- a/src/pages/DiaryCreatePage/index.jsx
+++ b/src/pages/DiaryCreatePage/index.jsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import React, { useState, useRef, useLayoutEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   Header,
   DiaryCreateStepOne,
@@ -15,6 +15,7 @@ import DefaultContainer from '@styles/DefaultContainer';
 import useForm from '@hooks/useForm';
 import { postImageUpload } from '@api/postImageUpload';
 import { postDiaryCreate } from '@api/postDiaryCreate';
+import { getExistenceDiaryDate } from '@api/getExistenceDiaryDate';
 
 const DefaultMarginTop = css`
   margin: 80px 0 80px 0;
@@ -28,6 +29,7 @@ const ButtonStyle = {
 };
 
 const DiaryCreatePage = () => {
+  const { albumId } = useParams();
   const [step, setStep] = useState(1);
   const navigate = useNavigate();
   const buttonRef = useRef();
@@ -42,7 +44,7 @@ const DiaryCreatePage = () => {
   const { date, title, content, photos } = values;
 
   const [inputErrors, setInputErrors] = useState({});
-  const { titleError, contentError } = inputErrors;
+  const { dateError, titleError, contentError } = inputErrors;
 
   useLayoutEffect(() => {
     const detectMobileKeyboard = () => {
@@ -60,7 +62,39 @@ const DiaryCreatePage = () => {
     return () => window.removeEventListener('resize', detectMobileKeyboard);
   }, []);
 
-  const handleNextButtonClick = () => {
+  const handleNextButtonClick = async () => {
+    if (step === 1) {
+      if (!date) {
+        setInputErrors((values) => ({
+          ...values,
+          dateError: '날짜를 선택해주세요.',
+        }));
+
+        return;
+      } else if (date) {
+        const data = {
+          albumId,
+          date,
+        };
+
+        try {
+          const { existence } = await getExistenceDiaryDate(data);
+
+          if (existence) {
+            setInputErrors((values) => ({
+              ...values,
+              dateError: '선택하신 날짜는 일기를 이미 작성하셨습니다.',
+            }));
+
+            return;
+          }
+        } catch (e) {
+          console.log(e.message);
+          return;
+        }
+      }
+    }
+
     if (step === 2) {
       if (title.length === 0) {
         setInputErrors((values) => ({
@@ -102,6 +136,7 @@ const DiaryCreatePage = () => {
 
     setInputErrors((values) => ({
       ...values,
+      dateError: '',
       titleError: '',
       contentError: '',
     }));
@@ -171,7 +206,13 @@ const DiaryCreatePage = () => {
 
   const renderDiaryCreateForm = () => {
     if (step === 1) {
-      return <DiaryCreateStepOne onChange={handleChange} date={date} />;
+      return (
+        <DiaryCreateStepOne
+          onChange={handleChange}
+          date={date}
+          dateError={dateError}
+        />
+      );
     } else if (step === 2) {
       return (
         <DiaryCreateStepTwo


### PR DESCRIPTION
## 📌 이슈
> closed #144 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- 일기 생성 일자 미입력의 경우 예외처리
- 선택한 일기 생성 일자에 이미 일기가 생성되어져 있는 경우에 대한 예외처리
  - 일기 중복 api 구현
  - api를 통한 로직 구현


## 📝 요약
<!-- PR 내용 요약 -->
두 가지 경우의 사용자 흐름에 대한 예외처리기능을 구현하였습니다.

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
![image](https://user-images.githubusercontent.com/57757719/146441872-280e9c09-13f0-4dfa-9c5d-790201f09169.png)
![image](https://user-images.githubusercontent.com/57757719/146442005-d964f78e-9a0e-4127-8802-e684f4930f13.png)
