### PR TITLE
[feat #152]

### DIFF
--- a/src/common/api/getAlbumInfo.jsx
+++ b/src/common/api/getAlbumInfo.jsx
@@ -1,0 +1,8 @@
+import api from './api';
+
+export const getAlbumInfo = async (albumId) => {
+  await api({
+    url: `/api/v1/albums/${albumId}`,
+    type: 'GET',
+  });
+};

--- a/src/common/api/putAlbumInfo.jsx
+++ b/src/common/api/putAlbumInfo.jsx
@@ -1,7 +1,8 @@
 import api from './api';
 
-export const getAlbumInfo = async (albumId) =>
+export const putAlbumInfo = async (albumId, params) =>
   await api({
     url: `/api/v1/albums/${albumId}`,
-    type: 'GET',
+    type: 'PUT',
+    params,
   });

--- a/src/pages/AlbumSettingsEditPage/index.jsx
+++ b/src/pages/AlbumSettingsEditPage/index.jsx
@@ -1,25 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import DefaultContainer from '@styles/DefaultContainer';
 import font from '@assets/fonts';
 import color from '@assets/colors';
 import { Input, Upload, Icon, Button } from '@components/base';
 import { DetailPageHeader } from '@components/domain';
+import { getAlbumInfo } from '@api/getAlbumInfo';
+import { putAlbumInfo } from '@api/putAlbumInfo';
+import { postImageUploads } from '@api/commonApi';
+import { useParams } from 'react-router';
+import { useForm } from '@hooks';
+import { css } from '@emotion/react';
 
 const ALBUM_EDIT_LIST = [
   {
-    name: 'ALBUM_TITLE',
+    name: 'title',
     text: '앨범 명을 입력해주세요.',
     placeholder: '예) 사랑하는 우리 가족 🥰',
     type: 'input',
   },
   {
-    name: 'ALBUM_PICTURE',
+    name: 'thumbnail',
     text: '대표 사진을 등록해주세요.',
     type: 'upload',
   },
   {
-    name: 'ALBUM_FAMILY_MOTTO',
+    name: 'familyMotto',
     text: '가훈을 입력해주세요.',
     placeholder: '예) 둥근 마음 열린 생각 바른 행동',
     type: 'input',
@@ -44,28 +50,111 @@ const ContentTitle = styled.span`
   ${font.content_16}
 `;
 
-const UploadWrapper = styled.div`
+const UploadStyle = css`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 266px;
+  width: 100%;
+  height: 288px;
   border: 1px solid ${color.brown};
   border-radius: 15px;
 `;
 
+const ThumbnailWrapper = styled.div`
+  display: flex;
+  background-image: url(${({ src }) => src || null});
+  background-size: cover;
+  background-position: center;
+  align-items: center;
+  justify-content: center;
+  border-radius: 15px;
+  width: 100%;
+  height: 100%;
+  background-repeat: no-repeat;
+`;
+
 const AlbumSettingsEditPage = () => {
+  const { albumId } = useParams();
+
+  const intialState = {
+    title: '',
+    thumbnail: '',
+    familyMotto: '',
+  };
+
+  const [albumInfo, setAlbumInfo] = useState(intialState);
+  const [image, setImage] = useState('');
+
+  const { values, isLoading, handleChange, handleSubmit } = useForm({
+    initialValues: intialState,
+    onSubmit: async () => {
+      for (let value in albumInfo) {
+        if (value === 'id') continue;
+        if (
+          values[value] === '' ||
+          values[value] === 0 ||
+          value === 'thumbnail'
+        ) {
+          values[value] = albumInfo[value];
+        }
+      }
+
+      if (image !== '') {
+        const imageUrl = await postImageUploads(image);
+        values.thumbnail = imageUrl;
+      }
+
+      try {
+        const res = await putAlbumInfo(albumId, values);
+        res && alert('성공적으로 변경되었습니다.');
+      } catch ({ response }) {
+        const { data } = response;
+        console.log(data);
+      }
+    },
+  });
+
+  useEffect(() => {
+    const getInfo = async () => {
+      try {
+        const {
+          data: { data },
+        } = await getAlbumInfo(albumId);
+        setAlbumInfo(data);
+      } catch (e) {
+        console.log(e.response);
+      }
+    };
+    getInfo();
+  }, [albumId]);
+
+  const handleUpload = (e) => {
+    const reader = new FileReader();
+    const image = e.target.files[0];
+    reader.readAsDataURL(image);
+    reader.onloadend = () => {
+      setAlbumInfo({ ...albumInfo, thumbnail: reader.result });
+      setImage(image);
+    };
+  };
+
+  console.log(albumInfo);
   const EditLists = (list) =>
-    list.map(({ name, text, placeholder, type }) => (
-      <ContentWrapper>
+    list.map(({ name, text, placeholder, type }, index) => (
+      <ContentWrapper key={index}>
         <ContentTitle>{text}</ContentTitle>
         {type === 'upload' ? (
-          <UploadWrapper>
-            <Upload>
-              <Icon name="fluent:camera-add-24-regular" height={48} />
-            </Upload>
-          </UploadWrapper>
+          <Upload onChange={handleUpload} name="thumbnail" css={UploadStyle}>
+            <ThumbnailWrapper src={albumInfo.thumbnail}>
+              <Icon name="fluent:camera-add-24-regular" height={32} />
+            </ThumbnailWrapper>
+          </Upload>
         ) : (
-          <Input name={name} placeholder={placeholder} />
+          <Input
+            name={name}
+            placeholder={placeholder}
+            onChange={handleChange}
+          />
         )}
       </ContentWrapper>
     ));
@@ -74,7 +163,7 @@ const AlbumSettingsEditPage = () => {
     <AlbumSettingsEditPageWrapper>
       <DetailPageHeader pageTitle="앨범 정보 수정" />
       {EditLists(ALBUM_EDIT_LIST)}
-      <Button mode="primary" onClick={() => {}}>
+      <Button mode="primary" onClick={handleSubmit}>
         확인
       </Button>
     </AlbumSettingsEditPageWrapper>

--- a/src/pages/AlbumSettingsEditPage/index.jsx
+++ b/src/pages/AlbumSettingsEditPage/index.jsx
@@ -146,7 +146,9 @@ const AlbumSettingsEditPage = () => {
         {type === 'upload' ? (
           <Upload onChange={handleUpload} name="thumbnail" css={UploadStyle}>
             <ThumbnailWrapper src={albumInfo.thumbnail}>
-              <Icon name="fluent:camera-add-24-regular" height={32} />
+              {!image && (
+                <Icon name="fluent:camera-add-24-regular" height={32} />
+              )}
             </ThumbnailWrapper>
           </Upload>
         ) : (

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -16,6 +16,8 @@ import {
   StoryBookPage,
   StoryBookDetailPage,
   ProfilePage,
+  AlbumSettingsPage,
+  AlbumSettingsEditPage,
   Error404Page,
 } from '@pages';
 import TestPage from '../pages/TestPage';
@@ -51,9 +53,10 @@ const Router = () => {
                   <Route path="" element={<MemberListPage />} />
                   <Route path="invite" element={<MemberInvitePage />} />
                 </Route>
-                {/* <Route path="settings" element={<AlbumSettingsPage />}> */}
-                {/* <Route path="edit" element={<AlbumSettingsEditPage />} /> */}
-                {/* </Route> */}
+                <Route path="settings/*">
+                  <Route path="" element={<AlbumSettingsPage />} />
+                  <Route path="edit" element={<AlbumSettingsEditPage />} />
+                </Route>
                 <Route path="storybook">
                   <Route path="" element={<StoryBookPage />} />
                   <Route


### PR DESCRIPTION
## 📌 이슈
> closed #152
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- 앨범 정보 수정 기능 API 연동

## 📝 요약

<!-- PR 내용 요약 -->
- input 항목을 입력하지 않고 제출하면 항목의 기존 앨범 정보를 유지하도록 하였습니다.
- UI 적인 측면에서 애매한 부분이 많은 것 같습니다.
  - 앨범 사진 업로드 영역에서의 내부 중앙 아이콘을 없애기에는 클릭 유도를 못할 것 같아 사진을 바꿔 업로드해도 아이콘이 남아있게 하였습니다. 근데 좀 못생겨보이는 원인인 것 같기도 합니다.
  - 사진을 업로드할 때 길이가 긴 사진 등 정사각형에서 벗어난 비율의 사진일수록 미리보기 영역에서의 렌더링이 못생겨집니다.. 고도화 작업에서 생각해보면 좋을 사안인 것 같습니다.
- 불필요한 리렌더링이 많은 것 같습니다.. 😭 불필요한 리렌더링을 잡으려고 하면 정상적으로 호출될 것들까지 안되어버리는 현상이 있어서 그냥 뒀습니다..
- 저만 그런건지 모바일 개발서버 접속이 안되어 PC환경으로만 확인했습니다.
- 확인버튼을 눌러서 제출 후 alert 로 수정이 완료되었다는 메세지를 출력하게 했습니다. (완료되어도 현 페이지 유지)
  - put api 요청에 대한 정상적인 응답 이후 alert 없이 바로 라우터 이동으로 페이지를 빠저 나오는 방법이 나을지? 
  - alert 를 모달로 대체하고 모달에서 확인버튼을 누르면 페이지를 빠져나오게 하는 방법이 나을지?
  - 현상태가 나을지?
- 앨범 정보 제출 후 UI 에서 딱히 `isLoading=true` 일 때의 로딩 렌더링을 어떻게 해야할지 구상이 안되어서 일단 isLoading은 아직 사용하지 않았습니다.

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
- 앨범 정보 수정 전

![image](https://user-images.githubusercontent.com/71081893/146684855-13aa6800-47b5-4ad1-ab10-cdce7771ea0a.png)

---

- 앨범 정소 수정 후
![image](https://user-images.githubusercontent.com/71081893/146684894-a8a3ae68-6f3b-4635-8ec7-298843fe208d.png)
