### PR TITLE
[Feat #175] 앨범 메인 페이지 Header api 통신 구현

### DIFF
--- a/src/common/api/albumApi.jsx
+++ b/src/common/api/albumApi.jsx
@@ -17,3 +17,14 @@ export const putInvitations = async ({ invitationId, status }) =>
     type: 'put',
     params: { status },
   });
+
+export const getAlbumTitleInfo = async ({ albumId }) => {
+  const {
+    data: { data },
+  } = await api({
+    url: `/api/v1/albums/${albumId}`,
+  });
+
+  console.log(data);
+  return data;
+};

--- a/src/common/api/albumApi.jsx
+++ b/src/common/api/albumApi.jsx
@@ -25,6 +25,5 @@ export const getAlbumTitleInfo = async ({ albumId }) => {
     url: `/api/v1/albums/${albumId}`,
   });
 
-  console.log(data);
   return data;
 };

--- a/src/components/domain/AlbumMainHeader/index.jsx
+++ b/src/components/domain/AlbumMainHeader/index.jsx
@@ -58,7 +58,7 @@ const AlbumMainHeader = ({ albumName, familyMotto, role }) => {
         <FamilyMotto>{familyMotto}</FamilyMotto>
       </ContentWrapper>
 
-      {role === 'OWNER' && (
+      {role === 'ROLE_ADMIN' && (
         <Button onClick={handleClickGoSetting}>
           <Icon
             name="ant-design:setting-filled"

--- a/src/pages/AlbumMainPage/index.jsx
+++ b/src/pages/AlbumMainPage/index.jsx
@@ -6,10 +6,14 @@ import {
   AlbumMainTimeline,
 } from '@components/domain';
 import { getAlbumMainDiaries } from '@api/getAlbumMainDiaries';
+import { getAlbumTitleInfo } from '@api/albumApi';
+import { useSelector } from 'react-redux';
 
 const AlbumMainPage = () => {
   const { albumId } = useParams();
   const [state, setState] = useState([]);
+  const [headerInfo, setHeaderInfo] = useState();
+  const role = useSelector((state) => state.member.data.memberRole);
 
   useEffect(() => {
     const fetchDiaries = async () => {
@@ -22,7 +26,17 @@ const AlbumMainPage = () => {
       }
     };
 
+    const fetchAlbumTitleInfo = async () => {
+      try {
+        const data = await getAlbumTitleInfo({ albumId });
+        setHeaderInfo(data);
+      } catch (e) {
+        console.log(e.response.data.message);
+      }
+    };
+
     fetchDiaries();
+    fetchAlbumTitleInfo();
   }, [albumId]);
 
   if (state.length === 0) return null;
@@ -30,9 +44,9 @@ const AlbumMainPage = () => {
   return (
     <>
       <AlbumMainHeader
-        albumName="극락이들"
-        familyMotto="코딩을 열씨미 하자"
-        role="OWNER"
+        albumName={headerInfo.title}
+        familyMotto={headerInfo.familyMotto}
+        role={role}
       />
       <AlbumMainTimeline diaries={state.diaries} />
       <Navigation />


### PR DESCRIPTION
## 📌 이슈
> closed #175 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- 앨범 메인 페이지 앨범 제목 및 가훈 조회 api 구현

## 📝 요약

<!-- PR 내용 요약 -->
- 앨범 메인 헤더 데이터 통신 구현

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
