### PR TITLE
[feat #187] 앨범 메인 페이지 초기 렌더링 이슈

### DIFF
--- a/src/components/domain/AlbumMainTimeline/index.jsx
+++ b/src/components/domain/AlbumMainTimeline/index.jsx
@@ -143,7 +143,7 @@ const AlbumMainTimeline = ({ diaries, children }) => {
                         <DimImage
                           src={image}
                           mode="cover"
-                          style={{ borderRadius: '0px' }}
+                          style={{ borderRadius: '6px' }}
                         >
                           <DiaryTitle>{diary.title}</DiaryTitle>
                           <DiaryDate>{diary.recordedAt}</DiaryDate>

--- a/src/pages/AlbumMainPage/index.jsx
+++ b/src/pages/AlbumMainPage/index.jsx
@@ -39,6 +39,7 @@ const AlbumMainPage = () => {
     fetchAlbumTitleInfo();
   }, [albumId]);
 
+  if (!headerInfo) return null;
   if (state.length === 0) return null;
 
   return (


### PR DESCRIPTION
## 📌 이슈
> closed #187 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- 앨범 선택 페이지에서 앨범 메인 페이지 라우팅 시 초기 렌더링 안되는 이슈 해결
- 일기 리스트 border 조정

## 📝 요약

<!-- PR 내용 요약 -->
- 앨범 메인 페이지 초기 UI 렌더링 이슈 해결

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
