### PR TITLE
[feat #191] 일기 상세 페이지 댓글 생성 시 추가된 동적 데이터에 삭제 버튼 UI 적용

### DIFF
--- a/src/components/domain/DiaryComment/index.jsx
+++ b/src/components/domain/DiaryComment/index.jsx
@@ -3,7 +3,6 @@ import font from '@assets/fonts';
 import color from '@assets/colors';
 import { forwardRef } from 'react';
 import { Icon } from '@components/base';
-import { useSelector } from 'react-redux';
 
 const Conatainer = styled.div`
   padding-top: 20px;
@@ -56,9 +55,7 @@ const Delete = styled.button`
   background: none;
 `;
 
-const DiaryComment = forwardRef(({ comments, onDelete }, ref) => {
-  const userInfo = useSelector((state) => state.member.data.memberEmail);
-
+const DiaryComment = forwardRef(({ comments, onDelete, userInfo }, ref) => {
   return (
     <Conatainer ref={ref}>
       {comments.map(

--- a/src/pages/DiaryPage/index.jsx
+++ b/src/pages/DiaryPage/index.jsx
@@ -106,7 +106,7 @@ const DiaryPage = () => {
         albumId,
         diaryId,
         cursorId: cursorId.current,
-        size: 10,
+        size: 15,
       };
 
       const data = await getDiaryComments(body);
@@ -153,7 +153,7 @@ const DiaryPage = () => {
 
       setState((state) => ({
         ...state,
-        comments: [newComment].concat(state.comments),
+        comments: [newComment].concat(...state.comments),
       }));
 
       setScrollType(() => 'Create');
@@ -178,6 +178,8 @@ const DiaryPage = () => {
             (comment) => comment.commentId !== Number(commentId),
           ),
         }));
+
+        createCommentInput.current.value = '';
       } catch (e) {
         console.log(e.response.data.message);
       }
@@ -256,6 +258,7 @@ const DiaryPage = () => {
         comments={comments}
         ref={scrollRef}
         hasNext={hasNext}
+        userInfo={email}
         onDelete={handleCommentDeleteClick}
       />
       <DiaryCommentInputForm


### PR DESCRIPTION
## 📌 이슈
> closed #191 
<!-- PR이 연결된 이슈 번호 작성 -->
<!-- ex) close #[이슈번호] -->

## 🛠 작업 사항

<!-- 리스트 기록해보기 -->
- 댓글 생성 시 받는 데이터 로직 변경에 따른 UI 구현
- 댓글 삭제 시 value 값 초기화

## 📝 요약
<!-- PR 내용 요약 -->
- 일기 상세 페이지 댓글 생성 시 추가된 동적 데이터에 상태 값 반영

## 📸 첨부

<!-- 참고자료링크 및 스토리북 결과물 Link -->
<!-- ex) 링크, 스크린샷 -->
